### PR TITLE
Don't crash if depending on proto_library targets without srcs

### DIFF
--- a/proto/proto_common.bzl
+++ b/proto/proto_common.bzl
@@ -112,8 +112,13 @@ def _lang_proto_aspect_impl(
     proto_info = _proto_info(target)
 
     direct_sources = _direct_sources(proto_info)
-    descriptors = _descriptors(proto_info)
     outputs = _create_outputs(actions, direct_sources, get_output_files)
+    if len(outputs) < 1:
+        # There is nothing to generate because the `proto_library` doesn't have
+        # sources (https://github.com/Yannic/rules_proto/issues/2).
+        return depset()
+
+    descriptors = _descriptors(proto_info)
 
     args = actions.args()
 

--- a/proto/tests/BUILD.bazel
+++ b/proto/tests/BUILD.bazel
@@ -85,3 +85,30 @@ proto_library(
         "//proto/tests:__subpackages__",
     ],
 )
+
+proto_library(
+    name = "no_srcs_proto",
+    visibility = [
+        "//proto/tests:__subpackages__",
+    ],
+)
+
+proto_library(
+    name = "no_srcs_deps_proto",
+    visibility = [
+        "//proto/tests:__subpackages__",
+    ],
+    deps = [
+        ":import_all_proto",
+    ],
+)
+
+proto_library(
+    name = "no_srcs_deps_no_srcs_proto",
+    visibility = [
+        "//proto/tests:__subpackages__",
+    ],
+    deps = [
+        ":no_srcs_proto",
+    ],
+)

--- a/proto/tests/compile/BUILD.bazel
+++ b/proto/tests/compile/BUILD.bazel
@@ -23,6 +23,27 @@ proto_compile(
     ],
 )
 
+proto_compile(
+    name = "no_srcs_proto_compile",
+    deps = [
+        "//proto/tests:no_srcs_proto",
+    ],
+)
+
+proto_compile(
+    name = "no_srcs_deps_proto_compile",
+    deps = [
+        "//proto/tests:no_srcs_deps_proto",
+    ],
+)
+
+proto_compile(
+    name = "no_srcs_deps_no_srcs_proto_compile",
+    deps = [
+        "//proto/tests:no_srcs_deps_no_srcs_proto",
+    ],
+)
+
 java_proto_library(
     name = "proto_source_root_import_full_java_proto",
     tags = [


### PR DESCRIPTION
Bug: 2